### PR TITLE
Fix missing test validation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,8 +27,9 @@
         },
         {
             "name": "Python: Current File",
+            "comment": "Needed to run 'Debug Tests' from the Testing Sidebar; see https://github.com/microsoft/vscode-python/issues/10847",
             "type": "python",
-            "request": "test",
+            "request": "test", 
             "console": "integratedTerminal"
         }
     ]

--- a/tests/test_pieces.py
+++ b/tests/test_pieces.py
@@ -80,6 +80,7 @@ class TestPawns:
         moves = pawn.get_available_moves(board)
 
         # Assert
+        assert Square.at(3, 4) in moves
         assert Square.at(4, 4) not in moves
 
     @staticmethod
@@ -99,4 +100,5 @@ class TestPawns:
         moves = pawn.get_available_moves(board)
 
         # Assert
+        assert Square.at(4, 4) in moves
         assert Square.at(3, 4) not in moves

--- a/tests/test_pieces.py
+++ b/tests/test_pieces.py
@@ -92,6 +92,7 @@ class TestPawns:
         board.set_piece(starting_square, pawn)
 
         intermediate_square = Square.at(5, 4)
+        board.current_player = Player.BLACK
         pawn.move_to(board, intermediate_square)
 
         # Act


### PR DESCRIPTION
Currently one test doesn't correctly test the scenario - it "moves" the black pawn on white's go which means it doesn't actually move (but usually passes because it only checks that a certain move isn't available, which it isn't)